### PR TITLE
Add OpenXRay engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Code
 * [Lumberyard](https://aws.amazon.com/pt/lumberyard/) - Amazon Lumberyard is a free AAA game engine deeply integrated
 * [ODE](http://www.ode.org/) - ODE is an open source, high performance library for simulating rigid body dynamics. :o2:
 * [Ogre3D](http://www.ogre3d.org/) -  is a scene-oriented, real-time, flexible 3D rendering engine (as opposed to a game engine) written in C++.
+* [OpenXRay](https://github.com/OpenXRay/xray-16) - a community-modified X-Ray engine used in S.T.A.L.K.E.R. game series. :triangular_flag_on_post:
 * [Panda3D](https://www.panda3d.org/) - a framework for 3D rendering and game development for Python and C++ programs.
 * [Paradox](http://paradox3d.net/) - Open Source C# Game Engine. :o2:
 * [Piston](http://www.piston.rs/) - a modular open source game engine written in Rust. :o2:


### PR DESCRIPTION
OpenXRay is a community-modified X-Ray engine used in S.T.A.L.K.E.R. game series. It's free for non-commercial use.

## Changes to the list
- [x] Added
- [ ] Removed
- [ ] Organized 

## Description
Add OpenXRay engine

## Checklist:
- [x] Checked for duplicate links
- [x] Removed all extra white space behind link and description
- [x] Changes are alphabetically
- [x] Added infomation is relevant to game development
