### PR TITLE
Removed Canyon Terrain Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,7 +500,6 @@ Tools
 
 ### Terrain Generators
 
-* [Canyon Terrain Editor](https://entardev.wordpress.com/other-projects/canyon-terrain-editor/) - Create quality, realistic terrain quickly and intuitively :free:
 * [Fracplanet](https://sourceforge.net/projects/fracplanet/) - Fractal planet and terrain generator
 * [Nem TG](http://nemesis.thewavelength.net/index.php?p=8) - 3D terrain generator
 * [World Machine](http://www.world-machine.com/) - Procedural terrain creation, simulations of nature, and interactive editing :heavy_dollar_sign:


### PR DESCRIPTION
The link worked but it went to a page that did not have a working copy of the software.  The link to the actual software redirects from the linked page redirects to localhost.

<!--- Provide a general summary of your changes in the Title above -->

<!--- Please fill out the following -->

## Changes to the list
<!--- Select one of the things you did -->
- [ ] Added
- [X ] Removed
- [ ] Organized 

## Description
<!--- What have you done? -->
Removed a link for Canyon Terrain Generator that was going to a live page, but the link on that live page was a dead link that redirected to a localhost of all things.  Very sketchy.

## Checklist:
- [ ] Checked for duplicate links
- [ ] Removed all extra white space behind link and description
- [ ] Changes are alphabetically
- [ ] Added infomation is relevant to game development
