### PR TITLE
Fix missing colon on emoji for World Machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ Tools
 
 * [Canyon Terrain Editor](https://entardev.wordpress.com/other-projects/canyon-terrain-editor/) - Create quality, realistic terrain quickly and intuitively :free:
 * [Fracplanet](https://sourceforge.net/projects/fracplanet/) - Fractal planet and terrain generator
-* [World Machine](http://www.world-machine.com/) - Procedural terrain creation, simulations of nature, and interactive editing :heavy_dollar_sign
+* [World Machine](http://www.world-machine.com/) - Procedural terrain creation, simulations of nature, and interactive editing :heavy_dollar_sign:
 
 ### Texturing
 


### PR DESCRIPTION

## Changes to the list
- [ ] Added
- [ ] Removed
- [X] Organized 

## Description
Emoji for World Machine wasn't escaped properly, so it didn't display as an emoji


## Checklist:
- [N/A] Checked for duplicate links
- [N/A] Removed all extra white space behind link and description
- [N/A] Changes are alphabetically
- [N/A] Added infomation is relevant to game development
