### PR TITLE
Add NativeBlend CLI to Modeling section

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,8 @@ Tools
 * :heavy_dollar_sign: [SketchUp](http://www.sketchup.com/) - 3D modeling computer program for a wide range of drawing application 
 * :heavy_dollar_sign: [Maya](http://www.autodesk.com/products/maya/overview) Industry animation software 
 * :heavy_dollar_sign: [3ds Max](http://www.autodesk.com/products/3ds-max/overview) Industry modeling software 
-* :triangular_flag_on_post: [Clara.io](https://clara.io/) - Start creating, rendering and sharing 3D 
+* :triangular_flag_on_post: [Clara.io](https://clara.io/) - Start creating, rendering and sharing 3D
+* :triangular_flag_on_post: [NativeBlend CLI](https://github.com/addy999/nativeblend-cli) - AI-powered CLI tool to generate and edit low-poly 3D game assets in Blender from natural language prompts
 
 ### Pixel Editor
 


### PR DESCRIPTION
## Summary

- Adds [NativeBlend CLI](https://github.com/addy999/nativeblend-cli) to the **Modeling** section under the 3D tools category
- NativeBlend is an open-source CLI tool that lets you generate and edit low-poly 3D game assets in Blender using natural language prompts (AI-powered)
- Marked as 🚩  (freemium) — free tier available, paid plans for more generations