### PR TITLE
Add Questlog to Project Management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Design
 * :triangular_flag_on_post: [ClickUp](https://clickup.com/) -  One app to replace them all. 
 * :heavy_dollar_sign: [Codecks](https://www.codecks.io) - Project Management Tool inspired by Collectible Card Games 
 * :triangular_flag_on_post: [HacknPlan](http://hacknplan.com/) - Project management for game developers 
+* :triangular_flag_on_post: [Questlog](https://www.questlog.build) - Project management built for game developers. Kanban boards, bug tracking with severity, milestones, and a built-in GDD editor. Free for solo devs. 
 * :triangular_flag_on_post: [Taiga](https://taiga.io/) - Project management platform for agile developers & designers 
 * :triangular_flag_on_post: [Trello](https://trello.com/) - Organize and prioritize projects 
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Design
 * :triangular_flag_on_post: [ClickUp](https://clickup.com/) -  One app to replace them all. 
 * :heavy_dollar_sign: [Codecks](https://www.codecks.io) - Project Management Tool inspired by Collectible Card Games 
 * :triangular_flag_on_post: [HacknPlan](http://hacknplan.com/) - Project management for game developers 
-* :triangular_flag_on_post: [Questlog](https://www.questlog.build) - Project management built for game developers. Kanban boards, bug tracking with severity, milestones, and a built-in GDD editor. Free for solo devs. 
+* :triangular_flag_on_post: [Questlog](https://www.questlog.build) - Project management for game developers with built-in GDD editor 
 * :triangular_flag_on_post: [Taiga](https://taiga.io/) - Project management platform for agile developers & designers 
 * :triangular_flag_on_post: [Trello](https://trello.com/) - Organize and prioritize projects 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Please fill out the following -->

## Changes to the list
<!--- Select one of the things you did -->
- [x] Added
- [ ] Removed
- [ ] Organized 

## Description
Adds Questlog to the Project Management list. It's a project management tool                                                                                                                                    
built specifically for game developers — Kanban boards, severity-based bug                                                                                                                                      
tracking, milestones with burndown, and a built-in GDD editor. Free forever                                                                                                                                  for solo developers. 

## Checklist:
- [x] Checked for duplicate links
- [x] Removed all extra white space behind link and description
- [x] Changes are alphabetically
- [x] Added infomation is relevant to game development
- [x] Added price tag 🅾️🆓🚩💲
