### PR TITLE
Add AnimKit to Animation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ Tools
 
 ### Animation
 
+* :heavy_dollar_sign: [AnimKit](https://www.nasrtech.dev/animkit) - Maya animation toolkit with live tweening, smart keys, motion trails, a pose library and Mixamo retargeting. An affordable animBot alternative.
 * :heavy_dollar_sign: [Fusion Character Animator](http://loopengo.free.fr/) - small tool for Clickteam Fusion 2.5 to facilitate the animation of 2D character sprites for developers. https://patlegoman.itch.io/fusion-character-animator
 * :o2: [ScreenToGif](https://github.com/NickeManarin/ScreenToGif) - record a selected area of your screen and save it as a Gif 
 * :heavy_dollar_sign: [Spine](http://esotericsoftware.com/) - Spine is dedicated to 2D animation, providing an efficient workflow both for creating amazing animation and for integrating it into your games. 


### PR DESCRIPTION
Adds **[AnimKit](https://www.nasrtech.dev/animkit)** to the *Animation* section (tagged `:heavy_dollar_sign:` — paid).

AnimKit is a Maya animation toolkit: live tweening, smart keys, speed-colored motion trails, a pose library with mirror/flip, and Mixamo auto-retargeting — an affordable animBot alternative for game animators working in Maya.

Thanks for maintaining this list!