### PR TITLE
Add Japanese Name Generator to Character Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ Tools
 ### Character Generators
 
 * :free: [Charas](http://charas-project.net/index.php) - Charas is a charset generator for RPG Maker. 
+* :free: [Japanese Name Generator](https://japanesenamegen.com) - Generates authentic Japanese character names with kanji, readings and meanings. 
 
 
 ### Design Tools


### PR DESCRIPTION
Adds [Japanese Name Generator](https://japanesenamegen.com) to the Character Generators section.

Useful for game devs naming Japanese or Japan-inspired characters: full names (surname + given name) from a database of 7,000+ real names, each with kanji, furigana reading, romaji and meaning. 150+ themed lists (samurai, mythology, names by letter...). Free, no signup, web-based.

Per CONTRIBUTING: link is not already in the list, relevant to gamedev (character naming), and placed in alphabetical order after Charas.

Disclosure: I built this site. Happy to adjust wording or placement.