### PR TITLE
Add Palette Extractor to Design Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ Tools
 * :heavy_dollar_sign: [articy:draft](http://www.nevigo.com/en/articydraft/overview/) visual environment for the creation and organization of game content. 
 * :free: [Dundoc](http://www.dundoc.com/) Game Design starter Template 
 * :triangular_flag_on_post: [Levelry](https://levelry.app) — Visual knowledge management and canvas for game designers.
+* :o2: [Palette Extractor](https://pixelpixi.github.io/spritewright/palette-extractor/) - Browser tool that extracts the exact colour palette out of any sprite or image and exports it as GIMP .gpl, Aseprite .pal, Lospec .hex, CSS, JSON or a PNG strip. Runs locally, nothing uploaded.
 * :free: [Palette Viewer](https://isometric8.itch.io/palette-viewert) A free tool to visualise palette files, supports hex, gimp, pal, text and images
 * :heavy_dollar_sign: [Scrivener](https://www.literatureandlatte.com/scrivener.php) Helps concentrate on composing and structuring long and difficult documents  
 * :free: [Tiny Game Design Tool](http://tinygdtool.urustar.net) small, portable booklet created in order to help game designers. 


### PR DESCRIPTION
Adds a free, open-source browser tool that pulls the exact colour palette out of a sprite, tileset or image.

**https://pixelpixi.github.io/spritewright/palette-extractor/** — source: https://github.com/pixelpixi/spritewright (MIT)

Exports GIMP `.gpl`, Aseprite `.pal`, Lospec `.hex`, CSS custom properties, JSON, or a PNG swatch strip. Runs entirely client-side — no upload, no account.

Against the contribution rules:
- **Not already listed** — the closest existing entry is *Palette Viewer*, which **reads** palette files; this one **extracts** a palette from an image, so they complement rather than duplicate each other.
- **Relevant** — palette extraction is a routine step in 2D/pixel-art asset work.
- **Alphabetical** — placed between *Levelry* and *Palette Viewer*.
- Tagged `:o2:` (Open Source) per the legend.

Disclosure: I wrote it.