### PR TITLE
Add ItsPaint to Vector/Image Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ Tools
 ### Vector/Image Editor
 
 * :o2: [Gimp](http://www.gimp.org/) - GNU Image Manipulation Program. It is a freely distributed piece of software for such tasks as photo retouching, image composition and image authoring. 
+* :o2: [ItsPaint](https://github.com/joshlin2201/itspaint) - Native macOS paint and image editor with a one-pixel pencil, pixel grid, nearest-neighbour zoom and PNG/GIF/ICO export.
 * :o2: [Krita](https://krita.org/) - Sketching and painting, offering an end-to-end solution for creating digital painting files from scratch by masters.
 * :o2: [Inkscape](https://inkscape.org/) - Inkscape is a free and open-source vector graphics editor for traditional Unix-compatible systems such as GNU/Linux, BSD derivatives and Illumos, as well as Windows and macOS.
 * :free: [Paint.NET](http://www.getpaint.net/) - Paint.NET is free image and photo editing software for PCs that run Windows. 


### PR DESCRIPTION
Adding ItsPaint to **Vector/Image Editor** with `:o2:` for open source, placed alphabetically as CONTRIBUTING asks.

[ItsPaint](https://github.com/joshlin2201/itspaint) is a native macOS image editor. The parts that matter for game work are the pixel-level ones: a one-pixel pencil, nearest-neighbour sampling above 100% zoom so a magnified pixel stays square, a pixel grid above 4x, live tool footprints, and PNG, GIF and ICO export.

What it does not have, so nobody installs it expecting otherwise: no indexed-palette mode, no tilemap or spritesheet tooling, no onion skinning, no animation timeline. Aseprite and LibreSprite are the right tools for sprite work and both are already on this list. This is the one you open for an icon or a quick placeholder.

MIT licensed, Swift with no third-party dependencies, notarised, free on the Mac App Store, 2.9 MB.

I put it in Vector/Image Editor rather than Pixel Editor deliberately — it has no sprite or animation workflow, so listing it beside the dedicated pixel-art tools would oversell it.
