### PR TITLE
Add Ludo.ai to Tools > AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ Tools
 
 ### AI
 * :triangular_flag_on_post: [Coplay](https://coplay.dev?ref=github&utm_source=gamedev_resources) - Multi-agent AI Assistant designed to amplify developer impact in Unity 
+* :triangular_flag_on_post: [Ludo.ai](https://ludo.ai) - AI sprite generator for game-ready 2D assets, extending to icons, UI, textures, music, 3D and video, in 30+ art styles, with MCP, REST API and Unity plugin integrations 
 * :triangular_flag_on_post: [Unity Muse](https://unity.com/products/muse) - Unity's suite of AI products
 
 ### Animation


### PR DESCRIPTION
Why do you think the link is worth adding on this list?
-------------------------------------------------------

The Tools > AI section currently has Coplay and Unity Muse, both engine-side assistants. Ludo.ai covers the asset side: it generates sprites and other game-ready 2D assets, extending to icons, UI, textures, music, 3D models and video.

Worth a line because of two things beyond "it generates images":

- **Consistency across a project.** 30+ preset art styles, or you supply your own style references and it matches them across every asset, so a project keeps one visual language.
- **It reaches your engine.** MCP server, REST API, and a Unity plugin for dragging assets into a scene, which fits the existing section's Unity focus.

Indie teams have shipped with it: [Echoes of Creation](https://ludo.ai/blog/indie-spotlight-echoes-of-creation) and [Abduct 'Em](https://ludo.ai/blog/indie-spotlight-abduct-em).

Does this project has any License?
----------------------------------

Proprietary, commercial SaaS. Free to start with 30 generation credits and no credit card, paid plans from $15/month, so I used `:triangular_flag_on_post:` (Limited Free) to match how Coplay and Unity Muse are tagged in the same section.

Entry is alphabetical between Coplay and Unity Muse, and the link is live.

---

Disclosure: I work on Ludo.ai, so this is a self-submission. Happy to shorten it, retag it, or drop the PR if it isn't a fit.
